### PR TITLE
Output file of the unique sequences, ordered by sequence

### DIFF
--- a/pycroquet/cli.py
+++ b/pycroquet/cli.py
@@ -61,7 +61,7 @@ HELP_LOW_COUNT = (
 )
 HELP_QUAL_OFFSET = "Specify phread offset (for fastq) if detection by readname fails"
 HELP_CPUS = "CPUs to use (0 to detect)"
-HELP_SGE_UNIQUE = "Only generate the unique sequence counts file, then exit"
+HELP_SGE_UNIQUE = "Only generate the unique sequence counts file, then exit (--guide can be omitted)"
 HELP_CHUNKS = "Reads per mapping block"
 HELP_MINSCORE = "Minimum score to retain, regardless of rule penalties.  Perfect match has score equal to query length."
 HELP_REFERENCE = "Required for cram"
@@ -132,9 +132,19 @@ def chunk_default(f):
 
 
 def sge_extra(f):
-    @click.option("--unique", required=False, type=bool, is_flag=True, help=HELP_SGE_UNIQUE)
+    @click.option("--unique", "unique_only", required=False, type=bool, is_flag=True, help=HELP_SGE_UNIQUE)
     @click.option(
         "--chunks", required=False, type=int, default=main.READ_CHUNK_SGE_INT, show_default=True, help=HELP_CHUNKS
+    )
+    @click.option(
+        "-n",
+        "--no-alignment",
+        required=False,
+        default=False,
+        type=bool,
+        help=HELP_NO_ALIGNMENT,
+        show_default=True,
+        is_flag=True,
     )
     @wraps(f)
     def wrapper(*args, **kwargs):
@@ -144,7 +154,7 @@ def sge_extra(f):
 
 
 def common_params(f):
-    @click.option("-g", "--guidelib", required=True, type=_file_exists(), help=HELP_GUIDELIB)
+    @click.option("-g", "--guidelib", required=False, default=None, type=_file_exists(), help=HELP_GUIDELIB)
     @click.option("-q", "--queries", required=True, type=_file_exists(), help=HELP_QUERIES)
     @click.option("-s", "--sample", required=False, type=str, help=HELP_SAMPLE)
     @click.option(
@@ -278,16 +288,6 @@ def dual_guide(*args, **kwargs):
 @cli.command()
 @common_params
 @sge_extra
-@click.option(
-    "-n",
-    "--no-alignment",
-    required=False,
-    default=False,
-    type=bool,
-    help=HELP_NO_ALIGNMENT,
-    show_default=True,
-    is_flag=True,
-)
 @debug_params
 def long_read(*args, **kwargs):
     """

--- a/pycroquet/cli.py
+++ b/pycroquet/cli.py
@@ -61,6 +61,7 @@ HELP_LOW_COUNT = (
 )
 HELP_QUAL_OFFSET = "Specify phread offset (for fastq) if detection by readname fails"
 HELP_CPUS = "CPUs to use (0 to detect)"
+HELP_SGE_UNIQUE = "Only generate the unique sequence counts file, then exit"
 HELP_CHUNKS = "Reads per mapping block"
 HELP_MINSCORE = "Minimum score to retain, regardless of rule penalties.  Perfect match has score equal to query length."
 HELP_REFERENCE = "Required for cram"
@@ -130,7 +131,8 @@ def chunk_default(f):
     return wrapper
 
 
-def chunk_sge(f):
+def sge_extra(f):
+    @click.option("--unique", required=False, type=bool, is_flag=True, help=HELP_SGE_UNIQUE)
     @click.option(
         "--chunks", required=False, type=int, default=main.READ_CHUNK_SGE_INT, show_default=True, help=HELP_CHUNKS
     )
@@ -275,7 +277,7 @@ def dual_guide(*args, **kwargs):
 
 @cli.command()
 @common_params
-@chunk_sge
+@sge_extra
 @click.option(
     "-n",
     "--no-alignment",

--- a/pycroquet/countwriter.py
+++ b/pycroquet/countwriter.py
@@ -27,6 +27,7 @@
 # statement that reads ‘Copyright (c) 2005-2012’ should be interpreted as being
 # identical to a statement that reads ‘Copyright (c) 2005, 2006, 2007, 2008,
 # 2009, 2010, 2011, 2012’.
+import gzip
 import json
 import logging
 import os
@@ -108,9 +109,9 @@ def query_counts(
     stats: Stats,
     output: str,
 ):
-    count_output = f"{output}.query_counts.tsv"
+    count_output = f"{output}.query_counts.tsv.gz"
     logging.info(f"Writing query counts file: {count_output}")
-    with open(count_output, "wt") as cout:
+    with gzip.open(count_output, "wt") as cout:
         print("##Command: " + stats.command, file=cout)
         print("##Version: " + stats.version, file=cout)
         print("#QUERY\tCOUNT", file=cout)

--- a/pycroquet/countwriter.py
+++ b/pycroquet/countwriter.py
@@ -101,3 +101,18 @@ def guide_counts_single(
     with open(stats_output, "wt") as jout:
         print(json.dumps(stats.__dict__, sort_keys=True, indent=2), file=jout)
     return (count_output, count_total)
+
+
+def query_counts(
+    query_dict: Dict[str, int],
+    stats: Stats,
+    output: str,
+):
+    count_output = f"{output}.query_counts.tsv"
+    logging.info(f"Writing query counts file: {count_output}")
+    with open(count_output, "wt") as cout:
+        print("##Command: " + stats.command, file=cout)
+        print("##Version: " + stats.version, file=cout)
+        print("#QUERY\tCOUNT", file=cout)
+        for k in sorted(query_dict.keys()):
+            print(f"{k}\t{query_dict[k]}", file=cout)

--- a/pycroquet/main.py
+++ b/pycroquet/main.py
@@ -148,7 +148,6 @@ def process_reads(
         exclude_qcfail=exclude_qcfail,
         exclude_by_len=exclude_by_len,
     )
-
     aligner = AlignerCpu(
         targets=library.targets,
         rules=rules,

--- a/pycroquet/main.py
+++ b/pycroquet/main.py
@@ -139,7 +139,6 @@ def process_reads(
     reverse=False,
     exclude_by_len=None,
     boundary_mode=3,
-    unique_only=False,
 ) -> Tuple[Dict[str, int], Dict[str, Tuple[str, List[Backtrack]]], Stats]:
     (unique, stats, query_dict, _) = readparser.parse_reads(
         seqfile,
@@ -149,9 +148,6 @@ def process_reads(
         exclude_qcfail=exclude_qcfail,
         exclude_by_len=exclude_by_len,
     )
-
-    if unique_only is True:
-        return (query_dict, None, None, stats)
 
     aligner = AlignerCpu(
         targets=library.targets,

--- a/pycroquet/main.py
+++ b/pycroquet/main.py
@@ -139,6 +139,7 @@ def process_reads(
     reverse=False,
     exclude_by_len=None,
     boundary_mode=3,
+    unique_only=False,
 ) -> Tuple[Dict[str, int], Dict[str, Tuple[str, List[Backtrack]]], Stats]:
     (unique, stats, query_dict, _) = readparser.parse_reads(
         seqfile,
@@ -148,6 +149,10 @@ def process_reads(
         exclude_qcfail=exclude_qcfail,
         exclude_by_len=exclude_by_len,
     )
+
+    if unique_only is True:
+        return (query_dict, None, None, stats)
+
     aligner = AlignerCpu(
         targets=library.targets,
         rules=rules,
@@ -200,4 +205,4 @@ def process_reads(
     stats.multimap_reads = multimap
     stats.unmapped_reads = unmapped
     stats.total_guides = len(library.guides)
-    return (guide_results, aligned_results, stats)
+    return (query_dict, guide_results, aligned_results, stats)

--- a/pycroquet/sge.py
+++ b/pycroquet/sge.py
@@ -50,6 +50,7 @@ def run(
     reference,
     excludeqcf,
     boundary_mode,
+    unique,
     chunks,
     no_alignment,
     loglevel,
@@ -63,7 +64,7 @@ def run(
     minscore = min_target_len - 10
 
     reverse = False
-    (guide_results, aligned_results, stats) = main.process_reads(
+    (query_dict, guide_results, aligned_results, stats) = main.process_reads(
         library,
         queries,
         workspace,
@@ -77,23 +78,27 @@ def run(
         reverse=reverse,
         exclude_by_len=min_target_len,
         boundary_mode=boundary_mode,
+        unique_only=unique,
     )
 
-    countwriter.guide_counts_single(library, guide_results, output, stats, low_count)
-    if no_alignment is False:
-        readwriter.reads_to_hts(
-            library,
-            aligned_results,
-            queries,
-            qual_offset,
-            workspace,
-            stats,
-            output,
-            usable_cpu,
-            exclude_qcfail=excludeqcf,
-            reference=reference,
-            reverse=reverse,
-        )
+    countwriter.query_counts(query_dict, stats, output, unique)
+
+    if unique is False:
+        countwriter.guide_counts_single(library, guide_results, output, stats, low_count)
+        if no_alignment is False:
+            readwriter.reads_to_hts(
+                library,
+                aligned_results,
+                queries,
+                qual_offset,
+                workspace,
+                stats,
+                output,
+                usable_cpu,
+                exclude_qcfail=excludeqcf,
+                reference=reference,
+                reverse=reverse,
+            )
 
     # TODO: write everything out and then if mapped count is a very low fraction repeat.  If the revcomp result is a higher
     # fraction then replace data

--- a/pycroquet/sge.py
+++ b/pycroquet/sge.py
@@ -33,6 +33,7 @@ from pycroquet import cli
 from pycroquet import countwriter
 from pycroquet import libparser
 from pycroquet import main
+from pycroquet import readparser
 from pycroquet import readwriter
 
 
@@ -50,7 +51,7 @@ def run(
     reference,
     excludeqcf,
     boundary_mode,
-    unique,
+    unique_only,
     chunks,
     no_alignment,
     loglevel,
@@ -58,32 +59,36 @@ def run(
     (usable_cpu, work_tmp, workspace, boundary_mode) = cli.common_setup(
         loglevel, cpus, workspace, output, boundary_mode
     )
-    library = libparser.load(guidelib)
-
-    min_target_len = library.min_target_len()
-    minscore = min_target_len - 10
 
     reverse = False
-    (query_dict, guide_results, aligned_results, stats) = main.process_reads(
-        library,
-        queries,
-        workspace,
-        rules,
-        minscore,
-        usable_cpu,
-        chunks,
-        sample=sample,
-        reference=reference,
-        exclude_qcfail=excludeqcf,
-        reverse=reverse,
-        exclude_by_len=min_target_len,
-        boundary_mode=boundary_mode,
-        unique_only=unique,
-    )
+    if unique_only is True:
+        (_, stats, query_dict, _) = readparser.parse_reads(
+            queries, sample=sample, cpus=cpus, reference=reference, exclude_qcfail=excludeqcf
+        )
+        countwriter.query_counts(query_dict, stats, output)
 
-    countwriter.query_counts(query_dict, stats, output)
+    if unique_only is False:
+        library = libparser.load(guidelib)
 
-    if unique is False:
+        min_target_len = library.min_target_len()
+        minscore = min_target_len - 10
+
+        (query_dict, guide_results, aligned_results, stats) = main.process_reads(
+            library,
+            queries,
+            workspace,
+            rules,
+            minscore,
+            usable_cpu,
+            chunks,
+            sample=sample,
+            reference=reference,
+            exclude_qcfail=excludeqcf,
+            reverse=reverse,
+            exclude_by_len=min_target_len,
+            boundary_mode=boundary_mode,
+        )
+        countwriter.query_counts(query_dict, stats, output)
         countwriter.guide_counts_single(library, guide_results, output, stats, low_count)
         if no_alignment is False:
             readwriter.reads_to_hts(

--- a/pycroquet/sge.py
+++ b/pycroquet/sge.py
@@ -81,7 +81,7 @@ def run(
         unique_only=unique,
     )
 
-    countwriter.query_counts(query_dict, stats, output, unique)
+    countwriter.query_counts(query_dict, stats, output)
 
     if unique is False:
         countwriter.guide_counts_single(library, guide_results, output, stats, low_count)

--- a/pycroquet/singleguide.py
+++ b/pycroquet/singleguide.py
@@ -60,7 +60,7 @@ def run(
 
     library = libparser.load(guidelib)
     reverse = False
-    (guide_results, aligned_results, stats) = main.process_reads(
+    (_, guide_results, aligned_results, stats) = main.process_reads(
         library,
         queries,
         workspace,


### PR DESCRIPTION
Always output the file of unique sequences, stop as soon as this is done if `--unique` flag provided.

Only applies to the `long-read` mode (SGE).

```bash
$ pycroquet long-read -g W5_A__parsed_library.pycroquet.tsv -q mini.fq -s BOB -o SGE_unique --unique
INFO: Number of duplicate guides: 0
INFO: Total unique guides: 1042
INFO: uncompressed data (assume fastq)
INFO: Parsed 800 reads, 757 were unique...
INFO: Read parsing took: 0s
INFO: Writing query counts file: /.../SGE_unique.query_counts.tsv.gz

$ zgrep -v '^#' /.../SGE_unique.query_counts.tsv.gz | cut -f 2 | sort | uniq -c
    751 1
      3 2
      2 3
      1 37
```